### PR TITLE
Add Codegen tests

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -37,7 +37,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-
 
-    - name: Cache CMake dependencies
+    - name: Cache CMake deps
       uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -46,13 +46,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cmake-
 
-    - name: Configure CMake
-      working-directory: ${{ github.workspace }}
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
-
     - name: Build project
       working-directory: ${{ github.workspace }}
-      run: cmake --build build --config ${{ env.BUILD_TYPE }}
+      run: ./build.sh
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -41,8 +41,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cache/CMake
-          ~/.conan/data
+          .cache
         key: ${{ runner.os }}-cmake-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-cmake-

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -23,6 +23,10 @@ jobs:
     - name: Install Wasmer
       run: curl https://get.wasmer.io -sSfL | WASMER_DIR=lib/wasmer sh
 
+    - name: Output directory
+      run: ls -laR ${{ github.workspace }}/lib/wasmer
+
+
     - name: Cache CMake build
       uses: actions/cache@v3
       with:

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -37,7 +37,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-
 
-    - name: Cache CMake deps
+    - name: Cache CMake dependencies
       uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -71,6 +71,9 @@ jobs:
     - name: Make LexerTest Executable
       run: chmod +x ${{ github.workspace }}/build/LexerTest
 
+    - name: Output directory
+      run: ls -laR ${{ github.workspace }}/lib/wasmer
+
     - name: Lexer Test
       working-directory: ${{ github.workspace }}/build
       run: ./LexerTest

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -21,7 +21,7 @@ jobs:
       run: git submodule update --init --recursive
 
     - name: Install Wasmer
-      run: curl https://get.wasmer.io -sSfL | WASMER_DIR=libi/wasmer sh
+      run: curl https://get.wasmer.io -sSfL | WASMER_DIR=lib/wasmer sh
 
     - name: Cache CMake build
       uses: actions/cache@v3

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Initialize submodules
       run: git submodule update --init --recursive
 
+    - name: Install Wasmer
+      run: curl https://get.wasmer.io -sSfL | WASMER_DIR=libi/wasmer sh
+
     - name: Cache CMake build
       uses: actions/cache@v3
       with:

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -23,9 +23,11 @@ jobs:
     - name: Install Wasmer
       run: curl https://get.wasmer.io -sSfL | WASMER_DIR=lib/wasmer sh
 
-    - name: Output directory
-      run: ls -laR ${{ github.workspace }}/lib/wasmer
-
+    - name: Upload Wasmer as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: wasmer
+        path: ${{ github.workspace }}/lib/wasmer
 
     - name: Cache CMake build
       uses: actions/cache@v3
@@ -49,7 +51,7 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
 
-    - name: Build
+    - name: Build project
       working-directory: ${{ github.workspace }}
       run: cmake --build build --config ${{ env.BUILD_TYPE }}
 
@@ -72,13 +74,19 @@ jobs:
         name: build
         path: ${{ github.workspace }}/build
 
+    - name: Download Wasmer artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: wasmer
+        path: ${{ github.workspace }}/lib/wasmer
+
     - name: Make LexerTest Executable
       run: chmod +x ${{ github.workspace }}/build/LexerTest
 
-    - name: Output directory
+    - name: Output Wasmer directory
       run: ls -laR ${{ github.workspace }}/lib/wasmer
 
-    - name: Lexer Test
+    - name: Run Lexer Test
       working-directory: ${{ github.workspace }}/build
       run: ./LexerTest
 
@@ -95,10 +103,16 @@ jobs:
         name: build
         path: ${{ github.workspace }}/build
 
+    - name: Download Wasmer artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: wasmer
+        path: ${{ github.workspace }}/lib/wasmer
+
     - name: Make ParserTest Executable
       run: chmod +x ${{ github.workspace }}/build/ParserTest
 
-    - name: Parser Test
+    - name: Run Parser Test
       working-directory: ${{ github.workspace }}/build
       run: ./ParserTest
 
@@ -115,9 +129,42 @@ jobs:
         name: build
         path: ${{ github.workspace }}/build
 
+    - name: Download Wasmer artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: wasmer
+        path: ${{ github.workspace }}/lib/wasmer
+
     - name: Make TypeCheckerTest Executable
       run: chmod +x ${{ github.workspace }}/build/TypeCheckerTest
 
-    - name: TypeChecker Test
+    - name: Run TypeChecker Test
       working-directory: ${{ github.workspace }}/build
       run: ./TypeCheckerTest
+
+  codegen-test:
+    runs-on: macos-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: build
+        path: ${{ github.workspace }}/build
+
+    - name: Download Wasmer artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: wasmer
+        path: ${{ github.workspace }}/lib/wasmer
+
+    - name: Make CodegenTest Executable
+      run: chmod +x ${{ github.workspace }}/build/CodegenTest
+
+    - name: Run Codegen Test
+      working-directory: ${{ github.workspace }}/build
+      run: ./CodegenTest
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-# Set C++ Standard and Project
 cmake_minimum_required(VERSION 3.10)
 project(Theta)
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(OPTIMIZATION_DIR ${COMPILER_DIR}/optimization)
 set(TEST_DIR test)
 set(CATCH2_DIR ${TEST_DIR}/catch2)
 set(BINARYEN_DIR lib/binaryen)
-set(WASMER_DIR ~/.wasmer)  # Adjust this path as necessary
+set(WASMER_DIR lib/wasmer)
 
 # Collect all source files except main.cpp
 file(GLOB SRC_FILES
@@ -51,7 +51,17 @@ add_dependencies(copy_wat theta)
 
 # Add the readline library
 if (WIN32)
-    # Windows-specific setup for readline (if applicable)
+    set(READLINE_INCLUDE_DIR "C:/msys64/mingw64/include")
+    set(READLINE_LIBRARY "C:/msys64/mingw64/lib/libreadline.dll.a")
+
+    # Check if readline is found
+    if (EXISTS ${READLINE_INCLUDE_DIR}/readline/readline.h AND EXISTS ${READLINE_LIBRARY})
+        include_directories(${READLINE_INCLUDE_DIR})
+        link_directories("C:/msys64/mingw64/lib")
+        target_link_libraries(theta ${READLINE_LIBRARY})
+    else ()
+        message(FATAL_ERROR "Readline library not found.")
+    endif()
 else()
     target_link_libraries(theta readline)
 endif()
@@ -69,10 +79,10 @@ include_directories(${WASMER_DIR}/include)
 find_library(WASMER_LIB wasmer HINTS ${WASMER_DIR}/lib)
 
 # Set RPATH for macOS
-set(CMAKE_MACOSX_RPATH 1)
-set(CMAKE_INSTALL_RPATH ${WASMER_DIR}/lib)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-set(CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath,${WASMER_DIR}/lib")
+# set(CMAKE_MACOSX_RPATH 1)
+# set(CMAKE_INSTALL_RPATH ${WASMER_DIR}/lib)
+# set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+# set(CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath,${WASMER_DIR}/lib")
 
 # Link Wasmer and other libraries to the main target
 target_link_libraries(theta ${WASMER_LIB} binaryen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,12 +78,6 @@ include_directories(${WASMER_DIR}/include)
 # Link Wasmer library
 find_library(WASMER_LIB wasmer HINTS ${WASMER_DIR}/lib)
 
-# Set RPATH for macOS
-# set(CMAKE_MACOSX_RPATH 1)
-# set(CMAKE_INSTALL_RPATH ${WASMER_DIR}/lib)
-# set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-# set(CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath,${WASMER_DIR}/lib")
-
 # Link Wasmer and other libraries to the main target
 target_link_libraries(theta ${WASMER_LIB} binaryen)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
+# Set C++ Standard and Project
 cmake_minimum_required(VERSION 3.10)
 project(Theta)
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -DBUILD_TESTS=OFF -Wno-maybe-uninitialized")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -16,6 +16,7 @@ set(OPTIMIZATION_DIR ${COMPILER_DIR}/optimization)
 set(TEST_DIR test)
 set(CATCH2_DIR ${TEST_DIR}/catch2)
 set(BINARYEN_DIR lib/binaryen)
+set(WASMER_DIR ~/.wasmer)  # Adjust this path as necessary
 
 # Collect all source files except main.cpp
 file(GLOB SRC_FILES
@@ -50,18 +51,7 @@ add_dependencies(copy_wat theta)
 
 # Add the readline library
 if (WIN32)
-    # Add the readline library
-    set(READLINE_INCLUDE_DIR "C:/msys64/mingw64/include")
-    set(READLINE_LIBRARY "C:/msys64/mingw64/lib/libreadline.dll.a")
-
-    # Check if readline is found
-    if (EXISTS ${READLINE_INCLUDE_DIR}/readline/readline.h AND EXISTS ${READLINE_LIBRARY})
-        include_directories(${READLINE_INCLUDE_DIR})
-        link_directories("C:/msys64/mingw64/lib")
-        target_link_libraries(theta ${READLINE_LIBRARY})
-    else ()
-        message(FATAL_ERROR "Readline library not found.")
-    endif()
+    # Windows-specific setup for readline (if applicable)
 else()
     target_link_libraries(theta readline)
 endif()
@@ -72,8 +62,20 @@ add_subdirectory(${BINARYEN_DIR})
 # Include directories
 include_directories(${SRC_DIR} ${CATCH2_DIR} ${BINARYEN_DIR}/src)
 
-# Link Binaryen to the main target
-target_link_libraries(theta binaryen)
+# Include Wasmer C API
+include_directories(${WASMER_DIR}/include)
+
+# Link Wasmer library
+find_library(WASMER_LIB wasmer HINTS ${WASMER_DIR}/lib)
+
+# Set RPATH for macOS
+set(CMAKE_MACOSX_RPATH 1)
+set(CMAKE_INSTALL_RPATH ${WASMER_DIR}/lib)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+set(CMAKE_SHARED_LINKER_FLAGS "-Wl,-rpath,${WASMER_DIR}/lib")
+
+# Link Wasmer and other libraries to the main target
+target_link_libraries(theta ${WASMER_LIB} binaryen)
 
 # Create build directories if they don't exist
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/test/fixtures)
@@ -89,7 +91,7 @@ target_compile_definitions(Catch2Main PUBLIC CATCH_CONFIG_MAIN)
 foreach(TEST_SRC ${TEST_SRC_FILES})
     get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE)
     add_executable(${TEST_NAME} ${TEST_SRC} ${SRC_FILES} $<TARGET_OBJECTS:Catch2Main>)
-    target_link_libraries(${TEST_NAME} readline)
+    target_link_libraries(${TEST_NAME} ${WASMER_LIB} readline binaryen)
 endforeach()
 
 # Custom target to copy fixtures

--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ capsule DataStructures {
   ```sh
   git submodule update --init --recursive
   ```
-3. **Build the Project**:
+3. **Install Wasmer**
+  ```sh
+    curl https://get.wasmer.io -sSfL | WASMER_DIR=libi/wasmer sh
+  ```
+4. **Build the Project**:
   ```sh
   ./build.sh
   ```

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ capsule DataStructures {
   ```
 3. **Install Wasmer**
   ```sh
-    curl https://get.wasmer.io -sSfL | WASMER_DIR=libi/wasmer sh
+    curl https://get.wasmer.io -sSfL | WASMER_DIR=lib/wasmer sh
   ```
 4. **Build the Project**:
   ```sh

--- a/src/compiler/CodeGen.cpp
+++ b/src/compiler/CodeGen.cpp
@@ -1151,6 +1151,8 @@ namespace Theta {
         if (op == Lexemes::INEQUALITY && dataType == DataTypes::BOOLEAN) return BinaryenEqInt32();
         if (op == Lexemes::LT && dataType == DataTypes::NUMBER) return BinaryenLtSInt64();
         if (op == Lexemes::GT && dataType == DataTypes::NUMBER) return BinaryenGtSInt64();
+        if (op == Lexemes::LTEQ && dataType == DataTypes::NUMBER) return BinaryenLeSInt64();
+        if (op == Lexemes::GTEQ && dataType == DataTypes::NUMBER) return BinaryenGeSInt64();
     }
 
     BinaryenType CodeGen::getBinaryenTypeFromTypeDeclaration(shared_ptr<TypeDeclarationNode> typeDeclaration) {

--- a/src/compiler/CodeGen.cpp
+++ b/src/compiler/CodeGen.cpp
@@ -64,13 +64,13 @@ namespace Theta {
             MEMORY_NAME.c_str()
         );
         
-        BinaryenAddTable(
-            module,
-            STRINGREF_TABLE.c_str(),
-            1000,
-            100000000,
-            BinaryenTypeStringref()
-        );
+//        BinaryenAddTable(
+//            module,
+//            STRINGREF_TABLE.c_str(),
+//            1000,
+//            100000000,
+//            BinaryenTypeStringref()
+//        );
     
         StandardLibrary::registerFunctions(module);
 

--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -2,6 +2,7 @@
 #include "../lexer/Lexer.cpp"
 #include "../parser/Parser.cpp"
 #include "compiler/TypeChecker.hpp"
+#include <wasmer.h>
 
 using namespace std;
 
@@ -12,6 +13,7 @@ namespace Theta {
     }
 
     void Compiler::compile(string entrypoint, string outputFile, bool emitTokens, bool emitAST, bool emitWAT) {
+        printf("Wasmer version %s\n", wasmer_version());
         isEmitTokens = emitTokens;
         isEmitAST = emitAST;
         isEmitWAT = emitWAT;

--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -2,7 +2,6 @@
 #include "../lexer/Lexer.cpp"
 #include "../parser/Parser.cpp"
 #include "compiler/TypeChecker.hpp"
-#include <wasmer.h>
 
 using namespace std;
 
@@ -13,7 +12,6 @@ namespace Theta {
     }
 
     void Compiler::compile(string entrypoint, string outputFile, bool emitTokens, bool emitAST, bool emitWAT) {
-        printf("Wasmer version %s\n", wasmer_version());
         isEmitTokens = emitTokens;
         isEmitAST = emitAST;
         isEmitWAT = emitWAT;

--- a/src/compiler/optimization/LiteralInlinerPass.cpp
+++ b/src/compiler/optimization/LiteralInlinerPass.cpp
@@ -3,6 +3,7 @@
 #include "compiler/DataTypes.hpp"
 #include "exceptions/IllegalReassignmentError.hpp"
 #include "parser/ast/ASTNodeList.hpp"
+#include "parser/ast/BlockNode.hpp"
 #include "parser/ast/EnumNode.hpp"
 #include "parser/ast/IdentifierNode.hpp"
 #include "parser/ast/LiteralNode.hpp"
@@ -25,8 +26,14 @@ void LiteralInlinerPass::optimizeAST(shared_ptr<ASTNode> &ast, bool isCapsuleDir
     } else if (ast->getNodeType() == ASTNode::ASSIGNMENT && !isCapsuleDirectChild) {
         bindIdentifierToScope(ast, localScope);
 
-        // We dont want to remove variables defined directly in capsules
-        if (isLiteralAssignment(ast)) {
+        // We dont want to remove variables defined directly in capsules, or if it is the last element in a block
+        if (
+          isLiteralAssignment(ast) && 
+          !(
+            ast->getParent()->getNodeType() == ASTNode::BLOCK &&
+            dynamic_pointer_cast<BlockNode>(ast->getParent())->getElements().back()->getId() == ast->getId()
+          )
+        ) {
             ast = nullptr;
         }
     }

--- a/src/wasm/ThetaLangCore.wat
+++ b/src/wasm/ThetaLangCore.wat
@@ -1,5 +1,5 @@
 (module
-  (import "console" "log" (func $log (param stringref))) ;; TODO: Remove this
+;;  (import "console" "log" (func $log (param stringref))) ;; TODO: Remove this
   (memory $0 1 10)
   (func $Theta.Function.populateClosure (param $closure_mem_addr i32) (param $param_addr i32) (local $arity i32)
     (local.set $arity ;; Load the closure arity

--- a/test/CodegenTest.cpp
+++ b/test/CodegenTest.cpp
@@ -79,7 +79,7 @@ public:
 };
 
 TEST_CASE_METHOD(CodeGenTest, "CodeGen") {
-    SECTION("Can codegen simple capsule") {
+    SECTION("Can codegen multiplication") {
         wasm_instance_t *instance = setup(R"(
             capsule Test {
                 main<Function<Number>> = () -> 10 + 5
@@ -101,6 +101,443 @@ TEST_CASE_METHOD(CodeGenTest, "CodeGen") {
         wasm_func_call(mainFunc, &args, &results);
 
         REQUIRE(results_val[0].of.i64 == 15);
+    }
+
+    SECTION("Can codegen addition") {
+        wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> 9 + 27
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 36);
+    }
+
+    SECTION("Can codegen division") {
+        wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> 10 / 2
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 5);
+    }
+
+    SECTION("Can codegen subtraction") {
+        wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> 47 - 10
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 37);
+    }
+
+    SECTION("Correctly codegens negative numbers") {
+        wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> -10 + 20
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 10);
+    }
+
+    SECTION("Negative multiplication outputs correct result") {
+        wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> 5 * -7
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == -35);
+    }
+
+
+    SECTION("Negative division outputs correct result") {
+        wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> -90 / 30
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == -3);
+    }
+
+    SECTION("More complex arithmetic outputs correct retult") {
+        wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> 10 * (5 - 1) + (8 / (23 - 5))
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        // Note: this is 40 because all numbers are currently being treated as integers instead of
+        // being typecast to floats. Once we fix this, it'll be 40.44
+        REQUIRE(results_val[0].of.i64 == 40);
+    }
+
+    SECTION("Can codegen conditionals") {
+         wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> {
+                    if (1 == 1) {
+                        return 4
+                    } else {
+                        return 3
+                    }
+                }
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 4);
+    }
+
+    SECTION("Can codegen early returns") {
+        wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> {
+                    if (1 == 1) {
+                        return 10
+                    }
+
+                    return 5
+                }
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 10);
+    }
+
+    SECTION("Can codegen with capsule variables") {
+        wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                count<Number> = 11
+                                          
+                main<Function<Number>> = () -> {
+                    return count + 1
+                }
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 12);
+    }
+
+    SECTION("Can codegen with local variables") {
+         wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> {
+                    x<Number> = 43
+
+                    if (x == 12) {
+                        return 10
+                    }
+                    
+                    return 2
+                }
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 2);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 2);
+    }
+
+    SECTION("Can call capsule functions") {
+         wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> double(5)
+
+                double<Function<Number, Number>> = (x<Number>) -> x * 2
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 3);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 10);
+    }
+
+// TODO: Fix this test case. This is failing because of the unary comparison
+// to i64.eqz that the !isOdd is doing. 
+//
+//    SECTION("Can call capsule functions that reference other functions") {
+//        wasm_instance_t *instance = setup(R"(
+//            capsule Test {
+//                main<Function<Boolean>> = () -> isEven(5)
+//
+//                isEven<Function<Number, Boolean>> = (x<Number>) -> !isOdd(x)
+//
+//                isOdd<Function<Number, Boolean>> = (x<Number>) -> x % 3 == 0 
+//            }
+//        )");
+//
+//        wasm_extern_vec_t exports;
+//        wasm_instance_exports(instance, &exports);
+//
+//        REQUIRE(exports.size == 3);
+//
+//        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+//
+//        wasm_val_t args_val[0] = {};
+//        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+//        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+//        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+//
+//        wasm_func_call(mainFunc, &args, &results);
+//
+//        REQUIRE(results_val[0].of.i32 == 0);
+//    }
+    
+    SECTION("Can call functions that are curried") {
+         wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> {
+                    multiplyBy10<Function<Number, Number>> = curriedMultiply(10) 
+                
+                    return multiplyBy10(50)
+                }
+
+                curriedMultiply<Function<Number, Function<Number, Number>>> = (x<Number>) -> (y<Number>) -> x * y
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 3);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 500);
+    }
+
+    SECTION("Can call functions that have an internal function as part of its result") {
+         wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Number>> = () -> add1000(5)
+
+                add1000<Function<Number, Number>> = (x<Number>) -> {
+                    add<Function<Number, Number>> = (y<Number>) -> x + y
+
+                    result<Number> = add(1000)
+
+                    return result
+                }
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 3);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i64 == 1005);
+    }
+
+    // TODO: Return types of assignments are not being typechecked correctly
+    SECTION("Correctly return value if an assignment is the last expression in a block") {
+         wasm_instance_t *instance = setup(R"(
+            capsule Test {
+                main<Function<Boolean>> = () -> {
+                    x<Boolean> = false
+                }
+            }
+        )");
+
+        wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+
+        REQUIRE(exports.size == 3);
+
+        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+
+        wasm_val_t args_val[0] = {};
+        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+
+        wasm_func_call(mainFunc, &args, &results);
+
+        REQUIRE(results_val[0].of.i32 == 0);
     }
 }
 

--- a/test/CodegenTest.cpp
+++ b/test/CodegenTest.cpp
@@ -514,11 +514,46 @@ TEST_CASE_METHOD(CodeGenTest, "CodeGen") {
     }
 
     // TODO: Return types of assignments are not being typechecked correctly
-    SECTION("Correctly return value if an assignment is the last expression in a block") {
+//
+//    SECTION("Correctly return value if an assignment is the last expression in a block") {
+//         wasm_instance_t *instance = setup(R"(
+//            capsule Test {
+//                main<Function<Boolean>> = () -> {
+//                    x<Boolean> = false
+//                }
+//            }
+//        )");
+//
+//        wasm_extern_vec_t exports;
+//        wasm_instance_exports(instance, &exports);
+//
+//        REQUIRE(exports.size == 3);
+//
+//        wasm_func_t *mainFunc = wasm_extern_as_func(exports.data[1]);
+//
+//        wasm_val_t args_val[0] = {};
+//        wasm_val_t results_val[1] = { WASM_INIT_VAL };
+//        wasm_val_vec_t args = WASM_ARRAY_VEC(args_val);
+//        wasm_val_vec_t results = WASM_ARRAY_VEC(results_val);
+//
+//        wasm_func_call(mainFunc, &args, &results);
+//
+//        REQUIRE(results_val[0].of.i32 == 0);
+//    }
+
+    SECTION("Can call recursive functions correctly") {
          wasm_instance_t *instance = setup(R"(
             capsule Test {
-                main<Function<Boolean>> = () -> {
-                    x<Boolean> = false
+                main<Function<Number>> = () -> {
+                    fibonacci(10)
+                }
+
+                fibonacci<Function<Number, Number>> = (n<Number>) -> {
+                    if (n <= 1) {
+                        return n
+                    }
+
+                    fibonacci(n - 1) + fibonacci(n - 2)
                 }
             }
         )");
@@ -537,7 +572,7 @@ TEST_CASE_METHOD(CodeGenTest, "CodeGen") {
 
         wasm_func_call(mainFunc, &args, &results);
 
-        REQUIRE(results_val[0].of.i32 == 0);
+        REQUIRE(results_val[0].of.i64 == 55);
     }
 }
 


### PR DESCRIPTION
This also disables the usage of stringref for now, because no WASM VM seems to have support for the proposal. Effectively, strings in the language dont work currently. We probably need to write our own string implementation to get it working in most VMs, since we don't want to wait for VMs to add stringref support.