### PR TITLE
feat(parser): #39 update type declaration syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ capsule DataStructures {
 ### Prerequisites
 - **C++ Compiler**: Make sure you have a compiler that supports C++17.
 
-1. **Clone the Repository**: 
+1. **Clone the Repository**:
   ```sh
   git clone https://github.com/alexdovzhanyn/ThetaLang.git
   cd ThetaLang

--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -232,10 +232,10 @@ namespace Theta {
                         expr = make_shared<ASTNodeList>(func_def);
                     }
 
-                    shared_ptr<ASTNodeList> params = dynamic_pointer_cast<ASTNodeList>(expr); 
+                    shared_ptr<ASTNodeList> params = dynamic_pointer_cast<ASTNodeList>(expr);
                     for (auto param : params->getElements()) {
                         param->setParent(params);
-                    } 
+                    }
 
                     func_def->setParameters(params);
 
@@ -269,7 +269,7 @@ namespace Theta {
                     match(Token::IDENTIFIER);
 
                     shared_ptr<StructDeclarationNode> str = make_shared<StructDeclarationNode>(currentToken.getLexeme(), parent);
-            
+
                     match(Token::BRACE_OPEN);
 
                     str->setValue(parseDict(str));
@@ -399,7 +399,7 @@ namespace Theta {
 
                     expr = make_shared<BinaryOperationNode>(currentToken.getLexeme(), parent);
                     left->setParent(expr);
-                
+
                     expr->setLeft(left);
                     expr->setRight(parseComparison(expr));
                 }
@@ -607,7 +607,7 @@ namespace Theta {
 
                     expr = make_shared<TupleNode>(parent);
                     left->setParent(expr);
-                
+
                     expr->setLeft(left);
                     expr->setRight(parseExpression(expr));
                 } else if (expr == nullptr) {
@@ -708,10 +708,8 @@ namespace Theta {
 
                 shared_ptr<ASTNode> ident = make_shared<IdentifierNode>(currentToken.getLexeme(), parent);
 
-                if (match(Token::OPERATOR, Lexemes::LT)) {
+                if (match(Token::COLON)) {
                     ident->setValue(parseType(ident));
-
-                    match(Token::OPERATOR, Lexemes::GT);
                 }
 
                 return ident;


### PR DESCRIPTION
- change type declaration syntax for better readability
Here’s a commit message and PR description following the conventional commit format:

### Description

This PR updates the syntax for type declarations to make it more intuitive and readable. Previously, types were declared using the format:

```
x<Function<Number, Number, Number>> = () -> ...
```

This has been changed to:

```
x: Function<Number, Number, Number> = () -> ...
```

The new format improves clarity by separating the variable from its type explicitly using a colon `:`.

### Changes
- Modified `src/parser/Parser.cpp` to support the new syntax for type declarations.

### Motivation
- Enhances readability of type declarations.
- Makes the distinction between variables and types clearer.

### Related Issues

#39 

### Missing Work

- Update tests to reflect the new type declaration format.
-  Verify existing test cases still pass.