### PR TITLE
REPL code execution

### DIFF
--- a/src/cli/CLI.cpp
+++ b/src/cli/CLI.cpp
@@ -1,129 +1,104 @@
+#include "CLI.hpp"
 #include <iostream>
 #include <algorithm>
-#include <readline/readline.h>
-#include <readline/history.h>
 #include "../../version.h"
 #include "../compiler/Compiler.hpp"
+#include "REPL.hpp"
 
+using namespace Theta;
 using namespace std;
 
-namespace Theta {
-    class CLI {
-        public:
-            static void parseCommand(int argc, char* argv[]) {
-                bool isEmitTokens = false;
-                bool isEmitAST = false;
-                bool isEmitWAT = false;
-                string sourceFile;
-                string outFile;
+void CLI::parseCommand(int argc, char* argv[]) {
+    bool isEmitTokens = false;
+    bool isEmitAST = false;
+    bool isEmitWAT = false;
+    string sourceFile;
+    string outFile;
 
-                if (argc == 1) {
-                    repl();
-                } else if (argc == 2) {
-                    string arg1 = argv[1];
+    if (argc == 1) {
+        REPL repl = REPL();
+        repl.readInput();
+    } else if (argc == 2) {
+        string arg1 = argv[1];
 
-                    if (arg1 == "--version") return printLanguageVersion();
-                    if (arg1 == "--help") return printUsageInstructions();
+        if (arg1 == "--version") return printLanguageVersion();
+        if (arg1 == "--help") return printUsageInstructions();
 
-                    sourceFile = argv[1];
-                } else {
-                    int i = 1;
+        sourceFile = argv[1];
+    } else {
+        int i = 1;
 
-                    while (i < argc) {
-                        string arg = argv[i];
+        while (i < argc) {
+            string arg = argv[i];
 
-                        if (arg == "-o") {
-                            outFile = argv[i + 1];
-                            i++;
-                        }
-                        else if (arg == "--emitTokens") isEmitTokens = true;
-                        else if (arg == "--emitAST") isEmitAST = true;
-                        else if (arg == "--emitWAT") isEmitWAT = true;
-                        else if (i == argc - 1) sourceFile = arg;
-                        else validateOption(arg);
-
-                        i++;
-                    }
-                }
-
-                if (sourceFile == "") return;
-
-                if (outFile == "") {
-                    bool reachedDelimiter = false;
-                    for (int i = 0; !reachedDelimiter; i++) {
-                        outFile += sourceFile[i];
-
-                        if (sourceFile[i + 1] == '.') reachedDelimiter = true;
-                    }
-
-                    outFile += ".wasm";
-                }
-
-                Theta::Compiler::getInstance().compile(sourceFile, outFile, isEmitTokens, isEmitAST, isEmitWAT);
+            if (arg == "-o") {
+                outFile = argv[i + 1];
+                i++;
             }
+            else if (arg == "--emitTokens") isEmitTokens = true;
+            else if (arg == "--emitAST") isEmitAST = true;
+            else if (arg == "--emitWAT") isEmitWAT = true;
+            else if (i == argc - 1) sourceFile = arg;
+            else validateOption(arg);
 
-            static string makeLink(string url, string text = "") {
-                return "\x1B]8;;" +  url + "\x1B\\" + (text != "" ? text : url) + "\x1B]8;;\x1B\\";
-            }
+            i++;
+        }
+    }
 
-       private:
-            static void printUsageInstructions() {
-                cout << "Theta Language Compiler CLI" << endl;
-                cout << "============================" << endl;
-                cout << endl;
-                cout << "Usage:" << endl;
-                cout << "  theta [options] <source_file>" << endl;
-                cout << endl;
-                cout << "Options:" << endl;
-                cout << "  -o <output_file>               Specify the output file name." << endl;
-                cout << "  --emitTokens                   Emit the tokenized representation of the source file produced by the lexer." << endl;
-                cout << "  --emitAST                      Emit the Abstract Syntax Tree (AST) representation produced by the parser." << endl;
-                cout << "  --emitWAT                      Emit the WebAssembly Text format (WAT) representation produced." << endl;
-                cout << "  --help                         Display this help message and exit." << endl;
-                cout << "  --version                      Display the currently installed Theta language version and exit." << endl;
-            }
+    if (sourceFile == "") return;
 
-            static void printLanguageVersion() {
-                cout << "Theta v" << VERSION_MAJOR << '.' << VERSION_MINOR << '.' << VERSION_PATCH << endl;
-            }
+    if (outFile == "") {
+        bool reachedDelimiter = false;
+        for (int i = 0; !reachedDelimiter; i++) {
+            outFile += sourceFile[i];
 
-            static bool validateOption(string option) {
-                vector<string> validOptions = {
-                    "--version",
-                    "--help",
-                    "--emitTokens",
-                    "--emitAST",
-                    "--emitWAT",
-                    "-o"
-                };
+            if (sourceFile[i + 1] == '.') reachedDelimiter = true;
+        }
 
-                if (find(validOptions.begin(), validOptions.end(), option) == validOptions.end()) {
-                    cout << "Invalid option: " + option << endl;
-                    return false;
-                }
+        outFile += ".wasm";
+    }
 
-                return true;
-            }
+    Theta::Compiler::getInstance().compile(sourceFile, outFile, isEmitTokens, isEmitAST, isEmitWAT);
+}
 
-            static void repl() {
-                cout << "Interactive Theta" << endl;
-                printLanguageVersion();
-                cout << "Report issues at " + makeLink("https://www.github.com/alexdovzhanyn/ThetaLang/issues") << endl;
-                cout << "CTRL+D to exit" << endl << endl;
+string CLI::makeLink(string url, string text) {
+    return "\x1B]8;;" +  url + "\x1B\\" + (text != "" ? text : url) + "\x1B]8;;\x1B\\";
+}
 
-                char* input;
+void CLI::printLanguageVersion() {
+    cout << "Theta v" << VERSION_MAJOR << '.' << VERSION_MINOR << '.' << VERSION_PATCH << endl;
+}
 
-                while ((input = readline("ith $> ")) != nullptr) {
-                    if (*input) add_history(input);
+void CLI::printUsageInstructions() {
+    cout << "Theta Language Compiler CLI" << endl;
+    cout << "============================" << endl;
+    cout << endl;
+    cout << "Usage:" << endl;
+    cout << "  theta [options] <source_file>" << endl;
+    cout << endl;
+    cout << "Options:" << endl;
+    cout << "  -o <output_file>               Specify the output file name." << endl;
+    cout << "  --emitTokens                   Emit the tokenized representation of the source file produced by the lexer." << endl;
+    cout << "  --emitAST                      Emit the Abstract Syntax Tree (AST) representation produced by the parser." << endl;
+    cout << "  --emitWAT                      Emit the WebAssembly Text format (WAT) representation produced." << endl;
+    cout << "  --help                         Display this help message and exit." << endl;
+    cout << "  --version                      Display the currently installed Theta language version and exit." << endl;
+}
 
-                    // TODO: Change this to get execution result once we get an interpreter built out
-                    Theta::Compiler::getInstance().compileDirect(input);
-                    Theta::Compiler::getInstance().clearExceptions();
-
-                    free(input);
-                }
-
-                cout << endl << endl << "Exiting ITH..." << endl;
-            }
+bool CLI::validateOption(string option) {
+    vector<string> validOptions = {
+        "--version",
+        "--help",
+        "--emitTokens",
+        "--emitAST",
+        "--emitWAT",
+        "-o"
     };
+
+    if (find(validOptions.begin(), validOptions.end(), option) == validOptions.end()) {
+        cout << "Invalid option: " + option << endl;
+        return false;
+    }
+
+    return true;
 }

--- a/src/cli/CLI.hpp
+++ b/src/cli/CLI.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+using namespace std;
+
+namespace Theta {
+    class CLI {
+    public:
+        static void parseCommand(int argc, char* argv[]);
+
+        static string makeLink(string url, string text = "");
+
+        static void printLanguageVersion();
+
+    private:
+        static void printUsageInstructions();
+
+        static bool validateOption(string option);
+    };
+}

--- a/src/cli/REPL.cpp
+++ b/src/cli/REPL.cpp
@@ -27,7 +27,7 @@ void REPL::readInput() {
   char* input;
   string accumulatedInput;
 
-  rl_pre_input_hook = prefillIndentation;
+  rl_pre_input_hook = preInputHook;
 
   while ((input = readline(getPrompt().c_str())) != nullptr) {
     accumulatedInput += string(input);
@@ -77,14 +77,12 @@ void REPL::execute(string source) {
   Compiler::getInstance().clearExceptions();
 }
 
-int REPL::prefillIndentation(const char *text, int count) {
+void REPL::prefillIndentation() {
   string indents(delimeterStack.size() * 2, ' ');
 
   rl_insert_text(indents.c_str());
   rl_point = rl_end;
   rl_redisplay();
- 
-  return 0;
 }
 
 string REPL::getPrompt() { 

--- a/src/cli/REPL.cpp
+++ b/src/cli/REPL.cpp
@@ -1,0 +1,42 @@
+#include "REPL.hpp"
+#include <iostream>
+#include <readline/readline.h>
+#include <readline/history.h>
+#include "compiler/Compiler.hpp"
+#include "CLI.hpp"
+#include "runtime/Runtime.hpp"
+
+using namespace Theta;
+using namespace std;
+
+REPL::REPL() {
+  cout << "Interactive Theta" << endl;
+  CLI::printLanguageVersion();
+  cout << "Report issues at " + CLI::makeLink("https://www.github.com/alexdovzhanyn/ThetaLang/issues") << endl;
+  cout << "CTRL+D to exit" << endl << endl;
+}
+
+REPL::~REPL() {
+  cout << endl << endl << "Exiting ITH..." << endl;
+}
+
+void REPL::readInput() {
+  char* input;
+
+  while ((input = readline("\x1B[32mith $>\x1B[0m ")) != nullptr) {
+    if (*input) add_history(input);
+
+    vector<char> wasm = Compiler::getInstance().compileDirect(input);
+
+    if (wasm.size() > 0) {
+      ExecutionContext context = Runtime::getInstance().execute(wasm, "main0");
+      
+      cout << "\x1B[33m    -> " << context.stringifiedResult() << "\x1B[0m" << endl << endl;
+    }
+
+    Compiler::getInstance().clearExceptions();
+
+    free(input);
+  }
+}
+

--- a/src/cli/REPL.cpp
+++ b/src/cli/REPL.cpp
@@ -1,5 +1,4 @@
 #include "REPL.hpp"
-#include <iostream>
 #include <readline/readline.h>
 #include <readline/history.h>
 #include "compiler/Compiler.hpp"

--- a/src/cli/REPL.cpp
+++ b/src/cli/REPL.cpp
@@ -5,9 +5,13 @@
 #include "compiler/Compiler.hpp"
 #include "CLI.hpp"
 #include "runtime/Runtime.hpp"
+#include <map>
 
 using namespace Theta;
 using namespace std;
+
+stack<char> REPL::delimeterStack;
+int REPL::lineNumber = 0;
 
 REPL::REPL() {
   cout << "Interactive Theta" << endl;
@@ -22,21 +26,88 @@ REPL::~REPL() {
 
 void REPL::readInput() {
   char* input;
+  string accumulatedInput;
 
-  while ((input = readline("\x1B[32mith $>\x1B[0m ")) != nullptr) {
-    if (*input) add_history(input);
+  rl_pre_input_hook = prefillIndentation;
 
-    vector<char> wasm = Compiler::getInstance().compileDirect(input);
+  while ((input = readline(getPrompt().c_str())) != nullptr) {
+    accumulatedInput += string(input);
+    lineNumber++;
 
-    if (wasm.size() > 0) {
-      ExecutionContext context = Runtime::getInstance().execute(wasm, "main0");
-      
-      cout << "\x1B[33m    -> " << context.stringifiedResult() << "\x1B[0m" << endl << endl;
+    // For multiline input. We keep a stack of the matching braces so we know once a statement is complete.
+    for (char &c : string(input)) {
+      if (c == '{' || c == '(' || c == '[') {
+        delimeterStack.push(c);
+      } else if (isMatchingDelimeter(c, delimeterStack)) {
+        delimeterStack.pop();
+      }
     }
 
-    Compiler::getInstance().clearExceptions();
+    // If all of the delimeters weren't resolved, take in more user input
+    if (!delimeterStack.empty()) {
+      // Only add the newline in the case where we expect more input. Otherwise it's pointless
+      accumulatedInput += "\n";
+      free(input);
 
+      string indents = "";
+      for (int i = 0; i < delimeterStack.size(); ++i) {
+        indents += "  ";
+      }
+
+      continue;
+    }
+
+    if (!accumulatedInput.empty()) execute(accumulatedInput);
+    
     free(input);
+    accumulatedInput.clear();
   }
 }
 
+void REPL::execute(string source) {
+  add_history(source.c_str());
+
+  vector<char> wasm = Compiler::getInstance().compileDirect(source);
+
+  if (wasm.size() > 0) {
+    ExecutionContext context = Runtime::getInstance().execute(wasm, "main0");
+    
+    cout << "\x1B[33m-----> " << context.stringifiedResult() << "\x1B[0m" << endl << endl;
+  }
+
+  Compiler::getInstance().clearExceptions();
+}
+
+int REPL::prefillIndentation(const char *text, int count) {
+  string indents(delimeterStack.size() * 2, ' ');
+
+  rl_insert_text(indents.c_str());
+  rl_point = rl_end;
+  rl_redisplay();
+ 
+  return 0;
+}
+
+string REPL::getPrompt() { 
+  string promptStyleSet = "\x1B[32m";
+  string promptStyleClear = "\x1B[0m";
+
+  string prompt = delimeterStack.size() == 0 ? "ith" : "...";
+  string line = "(" + to_string(lineNumber) + ")"; 
+
+  return promptStyleSet + prompt + line + " $> " + promptStyleClear;
+}
+
+bool REPL::isMatchingDelimeter(char &c, stack<char> delimeterStack) {
+  if (delimeterStack.empty()) return false;
+  
+  map<char, char> delimeterPairs = {
+    { '}', '{' },
+    { ')', '(' },
+    { ']', '['}
+  };
+
+  if (delimeterPairs.find(c) == delimeterPairs.end()) return false;
+  
+  return delimeterStack.top() == delimeterPairs.at(c);
+}

--- a/src/cli/REPL.hpp
+++ b/src/cli/REPL.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace Theta {
+  class REPL {
+  public:
+    REPL();
+    ~REPL();
+
+    void readInput();
+  };
+}

--- a/src/cli/REPL.hpp
+++ b/src/cli/REPL.hpp
@@ -1,5 +1,7 @@
 #pragma once
+
 #include <stack>
+#include <string>
 
 using namespace std;
 

--- a/src/cli/REPL.hpp
+++ b/src/cli/REPL.hpp
@@ -13,7 +13,19 @@ namespace Theta {
 
     void readInput();
     
-    static int prefillIndentation(const char *text, int count);
+    #ifdef __APPLE__
+    static int preInputHook(const char *text, int count) {
+      prefillIndentation();
+      return 0;
+    }
+    #else
+    static int preInputHook() {
+      prefillIndentation();
+      return 0;
+    }
+    #endif
+
+    static void prefillIndentation();
 
   private:
     static stack<char> delimeterStack;

--- a/src/cli/REPL.hpp
+++ b/src/cli/REPL.hpp
@@ -1,4 +1,7 @@
 #pragma once
+#include <stack>
+
+using namespace std;
 
 namespace Theta {
   class REPL {
@@ -7,5 +10,17 @@ namespace Theta {
     ~REPL();
 
     void readInput();
+    
+    static int prefillIndentation(const char *text, int count);
+
+  private:
+    static stack<char> delimeterStack;
+    static int lineNumber;
+
+    bool isMatchingDelimeter(char &c, stack<char> delimeterStack);
+
+    string getPrompt();
+
+    void execute(string source);
   };
 }

--- a/src/compiler/CodeGen.cpp
+++ b/src/compiler/CodeGen.cpp
@@ -24,7 +24,7 @@
 #include "parser/ast/FunctionDeclarationNode.hpp"
 #include "parser/ast/IdentifierNode.hpp"
 #include "parser/ast/TypeDeclarationNode.hpp"
-#include "cli/CLI.cpp"
+#include "cli/CLI.hpp"
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>

--- a/src/compiler/Compiler.cpp
+++ b/src/compiler/Compiler.cpp
@@ -49,10 +49,10 @@ namespace Theta {
         writeModuleToFile(module, outputFile);
     }
 
-    shared_ptr<ASTNode> Compiler::compileDirect(string source) {
+    vector<char> Compiler::compileDirect(string source) {
         shared_ptr<ASTNode> ast = buildAST(source, "ith");
 
-        if (!optimizeAST(ast)) return nullptr;
+        if (!optimizeAST(ast)) return {};
         
         outputAST(ast, "ith");
 
@@ -63,17 +63,12 @@ namespace Theta {
             encounteredExceptions[i]->display();
         }
 
-        if (!isTypeValid) return ast;
+        if (!isTypeValid) return {};
 
         CodeGen codeGen;
         BinaryenModuleRef module = codeGen.generateWasmFromAST(ast);
 
-        cout << "-> " + ast->toJSON() << endl;
-        cout << "-> ";
-        BinaryenModulePrint(module);
-        cout << endl;
-
-        return ast;
+        return writeModuleToBuffer(module);
     }
 
     shared_ptr<ASTNode> Compiler::buildAST(string file) {

--- a/src/compiler/Compiler.hpp
+++ b/src/compiler/Compiler.hpp
@@ -40,9 +40,9 @@ namespace Theta {
             /**
              * @brief Compiles the Theta source code starting from the specified entry point.
              * @param source The source code to compile.
-             * @return A shared pointer to the root node of the constructed AST
+             * @return A buffer containing the compiled WASM module
              */
-            shared_ptr<Theta::ASTNode> compileDirect(string source);
+            vector<char> compileDirect(string source);
 
             /**
              * @brief Builds the Abstract Syntax Tree (AST) for the Theta source code starting from the specified file.

--- a/src/runtime/ExecutionContext.hpp
+++ b/src/runtime/ExecutionContext.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "wasm.hh"
+#include <stdexcept>
 #include <vector>
 
 using namespace std;
@@ -12,5 +13,12 @@ namespace Theta {
       vector<string> exportNames;
 
       ExecutionContext(wasm::Val result, vector<string> exportNames) : result(std::move(result)), exportNames(exportNames) {}
+
+      string stringifiedResult() {
+        if (result.kind() == wasm::I64) return to_string(result.i64());
+        if (result.kind() == wasm::I32) return result.i32() == 1 ? "true" : "false";
+        
+        throw runtime_error("Could not parse result string");
+      }
   };
 }

--- a/theta.cpp
+++ b/theta.cpp
@@ -1,4 +1,4 @@
-#include "src/cli/CLI.cpp"
+#include "src/cli/CLI.hpp"
 
 using namespace std;
 


### PR DESCRIPTION
Changes the REPL to actually execute code instead of just outputting the compiled WASM. Also improves the REPL UX in general:

- Adds line numbers to prompt
- Allow for multiline input by detecting when an expression has ended
- Adds colors to a few places to liven things up a bit